### PR TITLE
Enrich airport data with external API details and METAR availability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ coverage.xml
 # Virtual Environment
 venv/
 ENV/
-.env
 
 # IDE
 .idea/
@@ -39,3 +38,4 @@ ENV/
 
 # Project specific
 temp_*.csv
+.env

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pandas==2.2.0
 numpy==1.26.4         # Required by pandas
 requests==2.31.0
 tqdm==4.66.1
+python-dotenv==1.0.1
 python-dateutil==2.8.2  # Required by pandas
 pytz==2024.1          # Required by pandas
 typing-extensions==4.9.0  # Required for type hints
@@ -21,3 +22,4 @@ pyarrow==15.0.0       # Required by pandas
 black==24.1.1         # Code formatting
 flake8==7.0.0         # Code linting
 mypy==1.8.0          # Type checking
+


### PR DESCRIPTION
## Summary
- load AirportDB API key from `.env` without committing the file
- only enrich medium/large airports in western Europe using the key and record METAR availability
- update tests to assert selective enrichment and API key usage

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac30e2211c832fa5d2d238c726d9ab